### PR TITLE
Update rook steps - checkout to stable rook branch

### DIFF
--- a/Install_OCP_4.2vmware.md
+++ b/Install_OCP_4.2vmware.md
@@ -622,11 +622,14 @@ storage                                    4.2.16    True        False         F
     oc label node storage3 role=storage-node
     ```
 
-3. Clone the rook project from github
+3. Clone the rook project from github & checkout to most stable branch of Rook
 
    ```bash
    cd /opt
    git clone https://github.com/rook/rook.git
+   cd /opt/rook
+   git stash
+   git checkout 3d5776f 
    ```
 
 4. You should now have a subdirectory under `/opt` named `rook`:


### PR DESCRIPTION
Using the most recent rook branch seems to cause failures; the branch 3d5776f is a stable branch which allows for a successful build. Added a step to cd to cloned rook directory, stash, and checkout to stable branch.